### PR TITLE
Create json burst indexes

### DIFF
--- a/src/index_safe/create_index.py
+++ b/src/index_safe/create_index.py
@@ -8,7 +8,7 @@ import zipfile
 from argparse import ArgumentParser
 from collections import ChainMap
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Union
 
 import boto3
 import numpy as np
@@ -137,16 +137,17 @@ def create_burst_name(slc_name: str, swath_name: str, burst_index: str) -> str:
     return '_'.join(all_parts) + '.tiff'
 
 
-def create_index(zipped_safe_path: str, zinfo: zipfile.ZipInfo, output_json: bool = True) -> Iterable[bytes]:
+def create_index(zipped_safe_path: str, zinfo: zipfile.ZipInfo, output_json: bool = True) -> Union[dict, bytes]:
     """Create a burst-specificindex containing information needed to download burst tiff from compressed
     SAFE file directly, and remove invalid data.
 
     Args:
         zipped_safe_path: Path to zipped SAFE
         zinfo: ZipInfo object for desired XML
+        output_json: Whether to output index as json or bytes
 
     Returns:
-        byte objects containing information needed to download and remove invalid data
+        dictionary or bytes object containing information needed to download and remove invalid data
     """
     slc_name = Path(zipped_safe_path).with_suffix('').name
     tiff_name = Path(zinfo.filename).name
@@ -170,7 +171,7 @@ def create_index(zipped_safe_path: str, zinfo: zipfile.ZipInfo, output_json: boo
         burst = utils.BurstMetadata(
             burst_name, slc_name, burst_shape, compressed_offset, index_burst_offset, burst_window
         )
-    
+
         if output_json:
             bstidx_name = Path(burst_name).with_suffix('.json').name
             burst_dictionary = burst.to_dict()
@@ -236,7 +237,7 @@ def save_xml_metadata_as_json(entries: utils.XmlMetadata, out_name: str) -> str:
     return out_name
 
 
-def index_safe(slc_name: str, edl_token: str = None, working_dir='.', keep: bool = True):
+def index_safe(slc_name: str, edl_token: str = None, working_dir='.', output_json: bool = True, keep: bool = True):
     """Create the index and other metadata needed to directly download
     and correctly format burst tiffs/metadata Sentinel-1 SAFE zip. Save
     this information in csv files. All information for extracting a burst is included in
@@ -245,10 +246,12 @@ def index_safe(slc_name: str, edl_token: str = None, working_dir='.', keep: bool
     Args:
         slc_name: Scene name to index
         edl_token: token for earth data login access
+        working_dir: Directory to save metadata and index files
+        output_json: Whether to output index as json or bytes
         keep: If False, delete SLC zip after indexing
 
     Returns:
-        No function outputs, but saves a metadata.csv, burst indexes to file
+        No function outputs, but saves a metadata.json, burst indexes to file
     """
     absolute_dir = Path(working_dir).resolve()
     zipped_safe_path = absolute_dir / f'{slc_name}.zip'
@@ -270,10 +273,12 @@ def index_safe(slc_name: str, edl_token: str = None, working_dir='.', keep: bool
     print('Reading Bursts...')
     burst_metadatas = dict(ChainMap(*[create_index(zipped_safe_path, x) for x in tqdm(tiffs)]))
 
-    # [(absolute_dir / key).write_bytes(value) for key, value in burst_metadatas.items()]
-    for key, value in burst_metadatas.items():
-        with open(key, 'w') as json_file:
-            json.dump(value, json_file)
+    if output_json:
+        for key, value in burst_metadatas.items():
+            with open(key, 'w') as json_file:
+                json.dump(value, json_file)
+    else:
+        [(absolute_dir / key).write_bytes(value) for key, value in burst_metadatas.items()]
 
     if not keep:
         os.remove(zipped_safe_path)
@@ -303,7 +308,6 @@ def main():
     parser.add_argument('scene')
     args = parser.parse_args()
     index_safe(args.scene)
-    # index_safe(args.scene, working_dir = 'tmpdir')
 
 
 if __name__ == '__main__':

--- a/src/index_safe/extract_burst.py
+++ b/src/index_safe/extract_burst.py
@@ -1,9 +1,11 @@
+import base64
+import json
 import os
 import struct
 import tempfile
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Tuple
 
 import boto3
 import numpy as np
@@ -11,6 +13,7 @@ import pandas as pd
 import requests
 import zran
 from osgeo import gdal
+
 
 try:
     from index_safe import utils
@@ -21,7 +24,7 @@ except ModuleNotFoundError:
 gdal.UseExceptions()
 
 KB = 1024
-MB = 1024 * KB
+MB = KB * KB
 
 BUCKET = 'asf-ngap2w-p-s1-slc-7b420b89'
 
@@ -119,7 +122,38 @@ def row_to_burst_entry(row: pd.Series) -> utils.BurstMetadata:
     return burst_entry
 
 
-def bytes_to_burst_entry(burst_name: str):
+def json_to_burst_metadata(burst_json_path: str) -> Tuple[zran.Index, utils.BurstMetadata]:
+    """Convert burst metadata json file to a BurstMetadata object and zran index file.
+
+    Args:
+        burst_json_path: path to burst metadata json file
+
+    Returns:
+        zran index file and BurstMetadata object
+    """
+    with open(burst_json_path, 'r') as json_file:
+        metadata_dict = json.load(json_file)
+
+    shape = (metadata_dict['n_rows'], metadata_dict['n_columns'])
+    index_offset = utils.Offset(metadata_dict['index_offset']['start'], metadata_dict['index_offset']['stop'])
+    decompressed_offset = utils.Offset(
+        metadata_dict['uncompressed_offset']['start'], metadata_dict['uncompressed_offset']['stop']
+    )
+    window = utils.Window(
+        metadata_dict['valid_window']['xstart'],
+        metadata_dict['valid_window']['xend'],
+        metadata_dict['valid_window']['ystart'],
+        metadata_dict['valid_window']['yend'],
+    )
+    burst_metadata = utils.BurstMetadata(
+        metadata_dict['name'], metadata_dict['slc'], shape, index_offset, decompressed_offset, window
+    )
+    decoded_bytes = base64.b64decode(metadata_dict['dflidx_64encoded'])
+    index = zran.Index.parse_index_file(decoded_bytes)
+    return index, burst_metadata
+
+
+def bytes_to_burst_entry(burst_name: str) -> Tuple[zran.Index, utils.BurstMetadata]:
     """Convert header bytes of burst-specifc
     index file to a burst metadata object.
     Index file must be in working directory.
@@ -130,6 +164,7 @@ def bytes_to_burst_entry(burst_name: str):
     Returns:
         burst metadata object
     """
+    burst_name = Path(burst_name)
     with open(str(burst_name.with_suffix('.bstidx')), 'rb') as f:
         byte_data = f.read(85)
         index_data = f.read()
@@ -191,7 +226,7 @@ def extract_burst(burst_name: str, edl_token: str = None, working_dir: Path = Pa
         path to saved burst raster
     """
     burst_path = working_dir / burst_name
-    index, burst_metadata = bytes_to_burst_entry(burst_path)
+    index, burst_metadata = json_to_burst_metadata(Path(burst_name).with_suffix('.json'))
     url = utils.get_download_url(burst_metadata.slc)
     burst_bytes = extract_bytes_by_burst(url, burst_metadata, index, edl_token, working_dir)
     burst_array = burst_bytes_to_numpy(burst_bytes, (burst_metadata.shape))
@@ -209,10 +244,10 @@ def lambda_handler(event, context):
     s3 = boto3.client('s3')
     index_bucket_name = os.environ.get('IndexBucketName')
     extract_bucket_name = os.environ.get('ExtractBucketName')
-    bstidx_name = Path(event['burst']).with_suffix('.bstidx')
+    burst_json_name = Path(event['burst']).with_suffix('.json')
     with tempfile.TemporaryDirectory() as tmpdirname:
         tmpdir = Path(tmpdirname)
-        s3.download_file(index_bucket_name, str(bstidx_name), str(tmpdir / bstidx_name))
+        s3.download_file(index_bucket_name, str(burst_json_name), str(tmpdir / burst_json_name))
         tmp_path = extract_burst(event['burst'], event['edl_token'], working_dir=tmpdir)
         s3.upload_file(str(tmp_path), extract_bucket_name, tmp_path.name)
     print('## PROCESS COMPLETE!')

--- a/src/index_safe/utils.py
+++ b/src/index_safe/utils.py
@@ -76,6 +76,26 @@ class BurstMetadata:
         byte_metadata = b'BURST' + struct.pack('<QQQQQQQQQQ', *data)
         return byte_metadata
 
+    def to_dict(self):
+        dictionary = {
+            'name': self.name,
+            'slc': self.slc,
+            'n_rows': int(self.shape[0]),
+            'n_columns': int(self.shape[1]),
+            'index_offset': {'start': int(self.index_offset.start), 'stop': int(self.index_offset.stop)},
+            'uncompressed_offset': {
+                'start': int(self.uncompressed_offset.start),
+                'stop': int(self.uncompressed_offset.stop),
+            },
+            'valid_window': {
+                'xstart': int(self.valid_window.xstart),
+                'xend': int(self.valid_window.xend),
+                'ystart': int(self.valid_window.ystart),
+                'yend': int(self.valid_window.yend),
+            },
+        }
+        return dictionary
+
 
 @dataclass(frozen=True)
 class XmlMetadata:


### PR DESCRIPTION
This PR would switch to using json to store the burst information needed to extract the burst data. JSON would be easier to read, but would create 33% larger files due to the base64 encoding.

For a burst catalog of 62,000,000 bursts, this would increase the storage needed from 1.67 TB to 2.29 TB and increase the monthly S3 storage costs from $38.50/month to $52.76/month, a difference of $14.26/month (33%). 

Tasks:
- [x] write index files as json
- [x] create reader for json-ified index files