### PR TITLE
Move auxiliary metadata functionality to `extract_burst`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.2]
+## [0.1.0]
 
 ### Added
 * Geographic control point information to indexes
 * Insertion of geographic control points into the output burst tiffs
 * Add check for deflate compression before indexing
+
+### Modified
+* `create_index` and `extract_burst` so that valid window and GCP calculations happen during `extract_burst`
+* `utils.BurstMetadata` so that it contains annotation and manifest offsets, but not valid window or GCP data
 
 ## [0.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Modified
 * `create_index` and `extract_burst` so that valid window and GCP calculations happen during `extract_burst`
 * `utils.BurstMetadata` so that it contains annotation and manifest offsets, but not valid window or GCP data
+* Created centralized range get request functionality in `utils`
 
 ## [0.0.1]
 

--- a/src/index_safe/create_index.py
+++ b/src/index_safe/create_index.py
@@ -11,8 +11,6 @@ from pathlib import Path
 from typing import Iterable, Union
 
 import boto3
-import numpy as np
-from osgeo import gdal
 from tqdm import tqdm
 
 
@@ -20,103 +18,6 @@ try:
     from index_safe import utils
 except ModuleNotFoundError:
     import utils
-
-gdal.UseExceptions()
-
-
-def compute_valid_window(index: int, burst: ET.Element) -> utils.Window:
-    """Written by Jason Ninneman for the ASF I&A team's burst extractor.
-    Using the information contained within a SAFE annotation XML burst
-    element, identify the window of a burst that contains valid data.
-
-    Args:
-        index: zero-indexed burst number to compute the valid window for
-        burst: <burst> element of annotation XML for the given index
-
-    Returns:
-        Row and column ranges for the valid data within a burst
-    """
-    # all offsets, even invalid offsets
-    offsets_range = utils.Offset(
-        np.array([int(val) for val in burst.find('firstValidSample').text.split()]),
-        np.array([int(val) for val in burst.find('lastValidSample').text.split()]),
-    )
-
-    # returns the indices of lines containing valid data
-    lines_with_valid_data = np.flatnonzero(offsets_range.stop - offsets_range.start)
-
-    # get first and last sample with valid data per line
-    # x-axis, range
-    valid_offsets_range = utils.Offset(
-        offsets_range.start[lines_with_valid_data].min(),
-        offsets_range.stop[lines_with_valid_data].max(),
-    )
-
-    # get the first and last line with valid data
-    # y-axis, azimuth
-    valid_offsets_azimuth = utils.Offset(
-        lines_with_valid_data.min(),
-        lines_with_valid_data.max(),
-    )
-
-    # x-length
-    length_range = valid_offsets_range.stop - valid_offsets_range.start
-    # y-length
-    length_azimuth = len(lines_with_valid_data)
-
-    valid_window = utils.Window(
-        valid_offsets_range.start,
-        valid_offsets_range.start + length_range,
-        valid_offsets_azimuth.start,
-        valid_offsets_azimuth.start + length_azimuth,
-    )
-
-    return valid_window
-
-
-def get_gcps_from_xml(annotation_xml: ET.Element) -> Iterable[utils.GeoControlPoint]:
-    """Get geolocation control points from annotation XML.
-
-    Args:
-        annotation_xml: root element of annotation XML
-
-    Returns:
-        List of geolocation control points
-    """
-    xml_gcps = annotation_xml.findall('.//{*}geolocationGridPoint')
-    gcps = []
-    for xml_gcp in xml_gcps:
-        pixel = int(xml_gcp.findtext('.//{*}pixel'))
-        line = int(xml_gcp.findtext('.//{*}line'))
-        longitude = round(float(xml_gcp.findtext('.//{*}longitude')), 7)
-        latitude = round(float(xml_gcp.findtext('.//{*}latitude')), 7)
-        height = round(float(xml_gcp.findtext('.//{*}height')), 7)
-        gcps.append(utils.GeoControlPoint(pixel, line, longitude, latitude, height))
-    return gcps
-
-
-def format_gcps_for_burst(
-    burst_number: int, burst_n_lines: int, swath_gcps: Iterable[utils.GeoControlPoint]
-) -> Iterable[utils.GeoControlPoint]:
-    """Format geolocation control points for a burst by making line numbers
-    relative to the burst, and removing any GCPs that are outside of the burst.
-
-    Args:
-        burst_number: zero-indexed burst number
-        burst_n_lines: number of lines in the burst
-        swath_gcps: list of geolocation control points for the entire swath
-
-    Returns:
-        List of geolocation control points for a particular burst
-    """
-    gcps = []
-    burst_starting_line = burst_number * burst_n_lines
-    for gcp in swath_gcps:
-        gcps.append(utils.GeoControlPoint(gcp.pixel, gcp.line - burst_starting_line, gcp.lon, gcp.lat, gcp.hgt))
-
-    # TODO: Why does this create incorrect geolocation
-    # relevant_gcps = [gcp for gcp in gcps if 0 <= gcp.line <= burst_n_lines]
-    return gcps
 
 
 def get_burst_annotation_data(zipped_safe_path: str, swath_path: str) -> Iterable:
@@ -132,7 +33,6 @@ def get_burst_annotation_data(zipped_safe_path: str, swath_path: str) -> Iterabl
         burst_shape: numpy-style tuple of burst array size (n rows, n columns)
         burst_offsets: uncompressed byte offsets for the bursts contained within
             a swath
-        burst_windows: row and column ranges for the valid data within a burst
     """
     swath_path = Path(swath_path)
     annotation_path = swath_path.parent.parent / 'annotation' / swath_path.with_suffix('.xml').name
@@ -147,10 +47,7 @@ def get_burst_annotation_data(zipped_safe_path: str, swath_path: str) -> Iterabl
     burst_starts = [int(x.findtext('.//{*}byteOffset')) for x in burst_xmls]
     burst_lengths = burst_starts[1] - burst_starts[0]
     burst_offsets = [utils.Offset(x, x + burst_lengths) for x in burst_starts]
-    burst_windows = [compute_valid_window(i, burst_xml) for i, burst_xml in enumerate(burst_xmls)]
-    swath_gcps = get_gcps_from_xml(xml)
-    burst_gcps = [format_gcps_for_burst(i, n_lines, swath_gcps) for i in range(len(burst_xmls))]
-    return burst_shape, burst_offsets, burst_windows, burst_gcps
+    return burst_shape, burst_offsets
 
 
 def create_xml_metadata(zipped_safe_path: str, zinfo: zipfile.ZipInfo) -> utils.XmlMetadata:
@@ -203,16 +100,18 @@ def create_index(
     """
     slc_name = Path(zipped_safe_path).with_suffix('').name
     tiff_name = Path(zinfo.filename).name
+    swath_name = Path(zinfo.filename).name.split('-')[1].upper()
     annotation_name = Path(zinfo.filename).with_suffix('.xml').name
+
     annotation_offset = [item for item in xml_metadatas if item.name == annotation_name][0].offset
     manifest_offset = [item for item in xml_metadatas if item.name == 'manifest.safe'][0].offset
-    burst_shape, burst_offsets, burst_windows, burst_gcps = get_burst_annotation_data(zipped_safe_path, zinfo.filename)
+    burst_shape, burst_offsets = get_burst_annotation_data(zipped_safe_path, zinfo.filename)
 
     bursts = {}
     indexer = utils.ZipIndexer(zipped_safe_path, tiff_name)
     indexer.create_full_dflidx()
-    for i, (burst_offset, burst_window, burst_gcp) in enumerate(zip(burst_offsets, burst_windows, burst_gcps)):
-        burst_name = create_burst_name(slc_name, zinfo.filename, i)
+    for burst_index, burst_offset in enumerate(burst_offsets):
+        burst_name = create_burst_name(slc_name, zinfo.filename, burst_index)
 
         compressed_offset, uncompressed_offset, modified_index = indexer.subset_dflidx(
             locations=[burst_offset.start], end_location=burst_offset.stop
@@ -226,13 +125,13 @@ def create_index(
         burst = utils.BurstMetadata(
             burst_name,
             slc_name,
+            swath_name,
+            burst_index,
             burst_shape,
             compressed_offset,
             index_burst_offset,
             annotation_offset,
             manifest_offset,
-            burst_window,
-            burst_gcp,
         )
 
         if output_json:

--- a/src/index_safe/extract_burst.py
+++ b/src/index_safe/extract_burst.py
@@ -78,7 +78,7 @@ def extract_burst_metadata(
     Returns:
         ElementTree root element of annotation XML
     """
-    annotation_range = f'bytes={metadata.annotation_offset.start}-{metadata.annotation_offset.stop}'
+    annotation_range = f'bytes={metadata.annotation_offset.start}-{metadata.annotation_offset.stop-1}'
     annotation_bytes = range_get_func(client, url, annotation_range)
     annotation_xml = ET.parse(io.BytesIO(zlib.decompressobj(-1 * zlib.MAX_WBITS).decompress(annotation_bytes)))
     return annotation_xml
@@ -337,7 +337,7 @@ def extract_burst(burst_index_path: str, edl_token: str = None, working_dir: Pat
     index, burst_metadata = json_to_burst_metadata(burst_index_path)
     url = utils.get_download_url(burst_metadata.slc)
 
-    client, range_get_func = utils.setup_download_client(strategy='http')
+    client, range_get_func = utils.setup_download_client(strategy='s3')
     burst_bytes = extract_burst_data(url, burst_metadata, index, client, range_get_func)
     annotation_xml = extract_burst_metadata(url, burst_metadata, client, range_get_func)
 

--- a/src/index_safe/extract_burst.py
+++ b/src/index_safe/extract_burst.py
@@ -1,8 +1,11 @@
 import base64
+import io
 import json
 import os
 import struct
 import tempfile
+import xml.etree.ElementTree as ET
+import zlib
 from argparse import ArgumentParser
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
@@ -28,6 +31,101 @@ KB = 1024
 MB = KB * KB
 
 BUCKET = 'asf-ngap2w-p-s1-slc-7b420b89'
+
+
+def compute_valid_window(index: int, burst: ET.Element) -> utils.Window:
+    """Written by Jason Ninneman for the ASF I&A team's burst extractor.
+    Using the information contained within a SAFE annotation XML burst
+    element, identify the window of a burst that contains valid data.
+
+    Args:
+        index: zero-indexed burst number to compute the valid window for
+        burst: <burst> element of annotation XML for the given index
+
+    Returns:
+        Row and column ranges for the valid data within a burst
+    """
+    # all offsets, even invalid offsets
+    offsets_range = utils.Offset(
+        np.array([int(val) for val in burst.find('firstValidSample').text.split()]),
+        np.array([int(val) for val in burst.find('lastValidSample').text.split()]),
+    )
+
+    # returns the indices of lines containing valid data
+    lines_with_valid_data = np.flatnonzero(offsets_range.stop - offsets_range.start)
+
+    # get first and last sample with valid data per line
+    # x-axis, range
+    valid_offsets_range = utils.Offset(
+        offsets_range.start[lines_with_valid_data].min(),
+        offsets_range.stop[lines_with_valid_data].max(),
+    )
+
+    # get the first and last line with valid data
+    # y-axis, azimuth
+    valid_offsets_azimuth = utils.Offset(
+        lines_with_valid_data.min(),
+        lines_with_valid_data.max(),
+    )
+
+    # x-length
+    length_range = valid_offsets_range.stop - valid_offsets_range.start
+    # y-length
+    length_azimuth = len(lines_with_valid_data)
+
+    valid_window = utils.Window(
+        valid_offsets_range.start,
+        valid_offsets_range.start + length_range,
+        valid_offsets_azimuth.start,
+        valid_offsets_azimuth.start + length_azimuth,
+    )
+
+    return valid_window
+
+
+def get_gcps_from_xml(annotation_xml: ET.Element) -> Iterable[utils.GeoControlPoint]:
+    """Get geolocation control points from annotation XML.
+
+    Args:
+        annotation_xml: root element of annotation XML
+
+    Returns:
+        List of geolocation control points
+    """
+    xml_gcps = annotation_xml.findall('.//{*}geolocationGridPoint')
+    gcps = []
+    for xml_gcp in xml_gcps:
+        pixel = int(xml_gcp.findtext('.//{*}pixel'))
+        line = int(xml_gcp.findtext('.//{*}line'))
+        longitude = round(float(xml_gcp.findtext('.//{*}longitude')), 7)
+        latitude = round(float(xml_gcp.findtext('.//{*}latitude')), 7)
+        height = round(float(xml_gcp.findtext('.//{*}height')), 7)
+        gcps.append(utils.GeoControlPoint(pixel, line, longitude, latitude, height))
+    return gcps
+
+
+def format_gcps_for_burst(
+    burst_number: int, burst_n_lines: int, swath_gcps: Iterable[utils.GeoControlPoint]
+) -> Iterable[utils.GeoControlPoint]:
+    """Format geolocation control points for a burst by making line numbers
+    relative to the burst, and removing any GCPs that are outside of the burst.
+
+    Args:
+        burst_number: zero-indexed burst number
+        burst_n_lines: number of lines in the burst
+        swath_gcps: list of geolocation control points for the entire swath
+
+    Returns:
+        List of geolocation control points for a particular burst
+    """
+    gcps = []
+    burst_starting_line = burst_number * burst_n_lines
+    for gcp in swath_gcps:
+        gcps.append(utils.GeoControlPoint(gcp.pixel, gcp.line - burst_starting_line, gcp.lon, gcp.lat, gcp.hgt))
+
+    # TODO: Why does this create incorrect geolocation
+    # relevant_gcps = [gcp for gcp in gcps if 0 <= gcp.line <= burst_n_lines]
+    return gcps
 
 
 def s3_range_get(client: boto3.client, key: str, range_header: str, bucket: str = BUCKET) -> bytes:
@@ -88,7 +186,11 @@ def extract_bytes_by_burst(
 
     length = metadata.uncompressed_offset.stop - metadata.uncompressed_offset.start
     burst_bytes = zran.decompress(body, index, metadata.uncompressed_offset.start, length)
-    return burst_bytes
+
+    annotation_range = f'bytes={metadata.annotation_offset.start}-{metadata.annotation_offset.stop}'
+    annotation_bytes = s3_range_get(client, Path(url).name, annotation_range)
+    annotation_xml = ET.parse(io.BytesIO(zlib.decompressobj(-1 * zlib.MAX_WBITS).decompress(annotation_bytes)))
+    return burst_bytes, annotation_xml
 
 
 def burst_bytes_to_numpy(burst_bytes: bytes, shape: Iterable[int]) -> np.ndarray:
@@ -141,15 +243,20 @@ def json_to_burst_metadata(burst_json_path: str) -> Tuple[zran.Index, utils.Burs
     decompressed_offset = utils.Offset(
         metadata_dict['uncompressed_offset']['start'], metadata_dict['uncompressed_offset']['stop']
     )
-    window = utils.Window(
-        metadata_dict['valid_window']['xstart'],
-        metadata_dict['valid_window']['xend'],
-        metadata_dict['valid_window']['ystart'],
-        metadata_dict['valid_window']['yend'],
+    annotation_offset = utils.Offset(
+        metadata_dict['annotation_offset']['start'], metadata_dict['annotation_offset']['stop']
     )
-    gcps = [utils.GeoControlPoint(**gcp) for gcp in metadata_dict['gcps']]
+    manifest_offset = utils.Offset(metadata_dict['manifest_offset']['start'], metadata_dict['manifest_offset']['stop'])
     burst_metadata = utils.BurstMetadata(
-        metadata_dict['name'], metadata_dict['slc'], shape, index_offset, decompressed_offset, window, gcps
+        metadata_dict['name'],
+        metadata_dict['slc'],
+        metadata_dict['swath'],
+        metadata_dict['burst_index'],
+        shape,
+        index_offset,
+        decompressed_offset,
+        annotation_offset,
+        manifest_offset,
     )
     decoded_bytes = base64.b64decode(metadata_dict['dflidx_b64'])
     index = zran.Index.parse_index_file(decoded_bytes)
@@ -246,10 +353,15 @@ def extract_burst(burst_index_path: str, edl_token: str = None, working_dir: Pat
     """
     index, burst_metadata = json_to_burst_metadata(burst_index_path)
     url = utils.get_download_url(burst_metadata.slc)
-    burst_bytes = extract_bytes_by_burst(url, burst_metadata, index, edl_token, working_dir)
+    burst_bytes, annotation_xml = extract_bytes_by_burst(url, burst_metadata, index, edl_token, working_dir)
     burst_array = burst_bytes_to_numpy(burst_bytes, (burst_metadata.shape))
-    burst_array = invalid_to_nodata(burst_array, burst_metadata.valid_window)
-    out_path = array_to_raster(burst_metadata.name, burst_array, burst_metadata.gcps)
+    valid_window = compute_valid_window(
+        burst_metadata.burst_index, annotation_xml.findall('.//{*}burst')[burst_metadata.burst_index]
+    )
+    burst_array = invalid_to_nodata(burst_array, valid_window)
+    swath_gcps = get_gcps_from_xml(annotation_xml)
+    gcps = format_gcps_for_burst(burst_metadata.burst_index, burst_metadata.shape[0], swath_gcps)
+    out_path = array_to_raster(burst_metadata.name, burst_array, gcps)
     return out_path
 
 

--- a/src/index_safe/extract_burst.py
+++ b/src/index_safe/extract_burst.py
@@ -10,7 +10,7 @@ from argparse import ArgumentParser
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import Callable, Iterable, Tuple
 
 import boto3
 import numpy as np
@@ -122,47 +122,105 @@ def format_gcps_for_burst(
     burst_starting_line = burst_number * burst_n_lines
     for gcp in swath_gcps:
         gcps.append(utils.GeoControlPoint(gcp.pixel, gcp.line - burst_starting_line, gcp.lon, gcp.lat, gcp.hgt))
-
-    # TODO: Why does this create incorrect geolocation
-    # relevant_gcps = [gcp for gcp in gcps if 0 <= gcp.line <= burst_n_lines]
     return gcps
 
 
-def s3_range_get(client: boto3.client, key: str, range_header: str, bucket: str = BUCKET) -> bytes:
-    """Get a range of bytes from an S3 object.
+def s3_range_get(client: boto3.client, url: str, range_header: str) -> bytes:
+    """Get a range of bytes from an S1 SLC file in ASF's archive.
     Used in threading to download a large file in chunks.
 
     Args:
         client: boto3 S3 client
-        key: S3 object key
+        url: url location of SLC file
         range_header: range header string
-        bucket: S3 bucket name (default is ASF's S1 SLC bucket)
+
     Returns:
         bytes of object
     """
+    key = Path(url).name
     resp = client.get_object(Bucket=BUCKET, Key=key, Range=range_header)
     body = resp['Body'].read()
     return body
 
 
-def extract_bytes_by_burst(
+def http_range_get(client: requests.Session, url: str, range_header: str) -> bytes:
+    """Get a range of bytes from an S1 SLC file in ASF's archive.
+    Used in threading to download a large file in chunks.
+
+    Args:
+        client: requests session
+        url: url location of SLC file
+        range_header: range header string
+
+    Returns:
+        bytes of object
+    """
+    resp = client.get(url, headers={'Range': range_header})
+    body = resp.content
+    return body
+
+
+def extract_burst_data(
     url: str,
     metadata: utils.BurstMetadata,
     index: zran.Index,
-    edl_token: str = None,
-    working_dir: Path = Path('.'),
-    strategy: str = 's3',
+    client: boto3.client,
+    range_get_func: Callable,
 ) -> bytes:
-    """Extract bytes pertaining to a burst from a Sentinel-1 SLC archive using a GZIDX that represents
-    a single burst. Index file must be in working directory.
+    """Extract bytes pertaining to a burst from a Sentinel-1 SLC archive using a zran index that represents
+    a single burst.
 
     Args:
         url: url location of SLC archive
         metadata: metadata object for burst to extract
-        strategy: strategy to use for download (s3 | http) s3 only works if runnning from us-west-2 region
+        index: zran index object for SLC archive
+        client: boto3 S3 client or requests session
+        range_get_func: function to use to get a range of bytes from SLC archive
 
     Returns:
-        bytes representing a single burst
+        bytes of burst data
+    """
+    total_size = (metadata.index_offset.stop - 1) - metadata.index_offset.start
+    range_headers = utils.calculate_range_parameters(total_size, metadata.index_offset.start, 20 * MB)
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        results = executor.map(range_get_func, repeat(client), repeat(url), range_headers)
+        body = b''.join(results)
+    length = metadata.uncompressed_offset.stop - metadata.uncompressed_offset.start
+    burst_bytes = zran.decompress(body, index, metadata.uncompressed_offset.start, length)
+    return burst_bytes
+
+
+def extract_burst_metadata(
+    url: str, metadata: utils.BurstMetadata, client: boto3.client, range_get_func: Callable
+) -> ET.Element:
+    """Extract and load bytes pertaining to a burst's partner annotation XML file from a Sentinel-1 SLC archive.
+
+    Args:
+        url: url location of SLC archive
+        metadata: metadata object for burst to extract
+        client: boto3 S3 client or requests session
+        range_get_func: function to use to get a range of bytes from SLC archive
+
+    Returns:
+        ElementTree root element of annotation XML
+    """
+    annotation_range = f'bytes={metadata.annotation_offset.start}-{metadata.annotation_offset.stop}'
+    annotation_bytes = range_get_func(client, url, annotation_range)
+    annotation_xml = ET.parse(io.BytesIO(zlib.decompressobj(-1 * zlib.MAX_WBITS).decompress(annotation_bytes)))
+    return annotation_xml
+
+
+def setup_download_client(strategy: str = 's3', edl_token: str = None, working_dir: Path = Path('.')) -> bytes:
+    """Create client and range_get_func for downloading from SLC archive based on strategy (s3 | http).
+
+    Args:
+        strategy: strategy to use for download (s3 | http) s3 only works if runnning from us-west-2 region
+        edl_token: EDL token for downloading from ASF's archive, if None will assume token is specified
+                   in environment variable EDL_TOKEN
+        working_dir: working directory where temparary credentials will be stored
+
+    Returns:
+        S3 client or http client, and matching *_range_get function
     """
     if strategy == 's3':
         creds = utils.get_credentials(edl_token, working_dir)
@@ -172,25 +230,13 @@ def extract_bytes_by_burst(
             aws_secret_access_key=creds["secretAccessKey"],
             aws_session_token=creds["sessionToken"],
         )
-        total_size = (metadata.index_offset.stop - 1) - metadata.index_offset.start
-        range_headers = utils.calculate_range_parameters(total_size, metadata.index_offset.start, 20 * MB)
-        with ThreadPoolExecutor(max_workers=20) as executor:
-            results = executor.map(s3_range_get, repeat(client), repeat(Path(url).name), range_headers)
-            body = b''.join(results)
+        range_get = s3_range_get
 
     elif strategy == 'http':
-        range_header = f'bytes={metadata.index_offset.start}-{metadata.index_offset.stop - 1}'
         client = requests.session()
-        resp = client.get(url, headers={'Range': range_header})
-        body = resp.content
+        range_get = http_range_get
 
-    length = metadata.uncompressed_offset.stop - metadata.uncompressed_offset.start
-    burst_bytes = zran.decompress(body, index, metadata.uncompressed_offset.start, length)
-
-    annotation_range = f'bytes={metadata.annotation_offset.start}-{metadata.annotation_offset.stop}'
-    annotation_bytes = s3_range_get(client, Path(url).name, annotation_range)
-    annotation_xml = ET.parse(io.BytesIO(zlib.decompressobj(-1 * zlib.MAX_WBITS).decompress(annotation_bytes)))
-    return burst_bytes, annotation_xml
+    return client, range_get
 
 
 def burst_bytes_to_numpy(burst_bytes: bytes, shape: Iterable[int]) -> np.ndarray:
@@ -353,7 +399,11 @@ def extract_burst(burst_index_path: str, edl_token: str = None, working_dir: Pat
     """
     index, burst_metadata = json_to_burst_metadata(burst_index_path)
     url = utils.get_download_url(burst_metadata.slc)
-    burst_bytes, annotation_xml = extract_bytes_by_burst(url, burst_metadata, index, edl_token, working_dir)
+
+    client, range_get_func = setup_download_client(strategy='s3')
+    burst_bytes = extract_burst_data(url, burst_metadata, index, client, range_get_func)
+    annotation_xml = extract_burst_metadata(url, burst_metadata, client, range_get_func)
+
     burst_array = burst_bytes_to_numpy(burst_bytes, (burst_metadata.shape))
     valid_window = compute_valid_window(
         burst_metadata.burst_index, annotation_xml.findall('.//{*}burst')[burst_metadata.burst_index]

--- a/src/index_safe/utils.py
+++ b/src/index_safe/utils.py
@@ -52,6 +52,8 @@ class BurstMetadata:
     shape: Iterable[int]  # n_row, n_column
     index_offset: Offset
     uncompressed_offset: Offset
+    annotation_offset: Offset
+    manifest_offset: Offset
     valid_window: Window
     gcps: Iterable[GeoControlPoint]
 
@@ -98,6 +100,14 @@ class BurstMetadata:
             'uncompressed_offset': {
                 'start': int(self.uncompressed_offset.start),
                 'stop': int(self.uncompressed_offset.stop),
+            },
+            'annotation_offset': {
+                'start': int(self.annotation_offset.start),
+                'stop': int(self.annotation_offset.stop),
+            },
+            'manifest_offset': {
+                'start': int(self.manifest_offset.start),
+                'stop': int(self.manifest_offset.stop),
             },
             'valid_window': {
                 'xstart': int(self.valid_window.xstart),

--- a/src/index_safe/utils.py
+++ b/src/index_safe/utils.py
@@ -49,13 +49,13 @@ class Window:
 class BurstMetadata:
     name: str
     slc: str
+    swath: str
+    burst_index: int
     shape: Iterable[int]  # n_row, n_column
     index_offset: Offset
     uncompressed_offset: Offset
     annotation_offset: Offset
     manifest_offset: Offset
-    valid_window: Window
-    gcps: Iterable[GeoControlPoint]
 
     def to_tuple(self):
         tuppled = (
@@ -94,6 +94,8 @@ class BurstMetadata:
         dictionary = {
             'name': self.name,
             'slc': self.slc,
+            'swath': self.swath,
+            'burst_index': self.burst_index,
             'n_rows': int(self.shape[0]),
             'n_columns': int(self.shape[1]),
             'index_offset': {'start': int(self.index_offset.start), 'stop': int(self.index_offset.stop)},
@@ -109,22 +111,6 @@ class BurstMetadata:
                 'start': int(self.manifest_offset.start),
                 'stop': int(self.manifest_offset.stop),
             },
-            'valid_window': {
-                'xstart': int(self.valid_window.xstart),
-                'xend': int(self.valid_window.xend),
-                'ystart': int(self.valid_window.ystart),
-                'yend': int(self.valid_window.yend),
-            },
-            'gcps': [
-                {
-                    'pixel': int(gcp.pixel),
-                    'line': int(gcp.line),
-                    'lon': float(gcp.lon),
-                    'lat': float(gcp.lat),
-                    'hgt': float(gcp.hgt),
-                }
-                for gcp in self.gcps
-            ],
         }
         return dictionary
 

--- a/tests/test_index_safe.py
+++ b/tests/test_index_safe.py
@@ -165,7 +165,7 @@ def test_get_zip_compressed_offset(golden_zip, zinfo, golden_bytes):
 
 # Burst level
 def test_get_burst_annotation_data(golden_zip, zinfo):
-    burst_shape, burst_offsets, burst_windows, _ = create_index.get_burst_annotation_data(golden_zip, zinfo.filename)
+    burst_shape, burst_offsets = create_index.get_burst_annotation_data(golden_zip, zinfo.filename)
 
     assert burst_shape == BURST_SHAPE
     assert burst_offsets[7].start == BURST_START


### PR DESCRIPTION
This PR moves auxiliary metadata functionality (valid window and GCPs) from `create_index` to `extract_burst` for two reasons:

1. With the addition of GCPs (and potentially the I&A's burst naming scheme), the burst tif index files were becoming bloated.
2. Too much functionality was present on the `create_index` side of the workflow. We want to avoid this situation because any bugs on the `create_index` side will force us to recreate indexes, which is expensive.

To accomplish this, we have to download the appropriate annotation xml during the extraction, but initial tests on a `r5d.xlarge` EC2 instance show that this only increase the runtime of the extractor by ~0.1 seconds.