### PR TITLE
Remove byte file format for burst indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.1.1]
+## [0.2.0]
 
 ### Added
 * Tests for utils.py
@@ -18,9 +18,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Modified
 * Standardize all xml operations so that they use lxml
+* `extract_metadata` polarization option is now required
 
 ### Removed
 * Original (limited) test suite dependent on S1 SLC
+* Burst index byte format removed in favor of json format
 
 ## [0.1.0]
 

--- a/src/index_safe/create_index.py
+++ b/src/index_safe/create_index.py
@@ -195,6 +195,22 @@ def save_xml_metadata_as_json(entries: Iterable[utils.XmlMetadata], out_name: st
     return out_name
 
 
+def save_burst_metadata_as_json(burst_metadata_dict: dict, working_dir: Path) -> Path:
+    """Save a dictionary of burst metadata objects as jsons.
+
+    Args:
+        burst_metadata_dict: Dictionary of burst metadata objects to be included with pattern 
+        working_dir: Directory to save jsons at
+
+    Returns:
+        Directory where jsons were saved
+    """
+    for key, value in burst_metadata_dict.items():
+        with open(working_dir / key, 'w') as json_file:
+            json.dump(value, json_file)
+    return working_dir
+
+
 def get_indexes(zipped_safe_path: Path) -> Iterable:
     """Get indexes for XML and bursts in zipped SAFE.
 
@@ -234,7 +250,7 @@ def get_indexes(zipped_safe_path: Path) -> Iterable:
     return xml_metadatas, burst_metadatas
 
 
-def index_safe(slc_name: str, edl_token: str = None, working_dir='.', output_json: bool = True, keep: bool = True):
+def index_safe(slc_name: str, edl_token: str = None, working_dir='.', keep: bool = True):
     """Create the index and other metadata needed to directly download
     and correctly format burst tiffs/metadata Sentinel-1 SAFE zip. Save
     this information in json files. All information for extracting a burst is included in
@@ -244,7 +260,6 @@ def index_safe(slc_name: str, edl_token: str = None, working_dir='.', output_jso
         slc_name: Scene name to index
         edl_token: token for earth data login access
         working_dir: Directory to save metadata and index files
-        output_json: Whether to output index as json or bytes
         keep: If False, delete SLC zip after indexing
 
     Returns:
@@ -261,13 +276,7 @@ def index_safe(slc_name: str, edl_token: str = None, working_dir='.', output_jso
     xml_metadatas, burst_metadatas = get_indexes(zipped_safe_path)
 
     save_xml_metadata_as_json(xml_metadatas, str(absolute_dir / f'{slc_name}_metadata.json'))
-
-    if output_json:
-        for key, value in burst_metadatas.items():
-            with open(absolute_dir / key, 'w') as json_file:
-                json.dump(value, json_file)
-    else:
-        [(absolute_dir / key).write_bytes(value) for key, value in burst_metadatas.items()]
+    save_burst_metadata_as_json(burst_metadatas, absolute_dir)
 
     if not keep:
         os.remove(zipped_safe_path)

--- a/src/index_safe/create_index.py
+++ b/src/index_safe/create_index.py
@@ -199,7 +199,7 @@ def save_burst_metadata_as_json(burst_metadata_dict: dict, working_dir: Path) ->
     """Save a dictionary of burst metadata objects as jsons.
 
     Args:
-        burst_metadata_dict: Dictionary of burst metadata objects to be included with pattern 
+        burst_metadata_dict: Dictionary of burst metadata objects to be included with pattern
         working_dir: Directory to save jsons at
 
     Returns:

--- a/src/index_safe/extract_metadata.py
+++ b/src/index_safe/extract_metadata.py
@@ -221,7 +221,7 @@ def main():
     """
     parser = ArgumentParser()
     parser.add_argument('metadata_path')
-    parser.add_argument('--polarization', default='vv')
+    parser.add_argument('polarization')
     args = parser.parse_args()
 
     extract_metadata(args.metadata_path, args.polarization)

--- a/src/index_safe/utils.py
+++ b/src/index_safe/utils.py
@@ -1,7 +1,6 @@
 import json
 import math
 import os
-import struct
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone

--- a/src/index_safe/utils.py
+++ b/src/index_safe/utils.py
@@ -82,39 +82,6 @@ class BurstMetadata:
     annotation_offset: Offset
     manifest_offset: Offset
 
-    def to_tuple(self):
-        tuppled = (
-            self.name,
-            self.slc,
-            self.shape[0],
-            self.shape[1],
-            self.index_offset.start,
-            self.index_offset.stop,
-            self.uncompressed_offset.start,
-            self.uncompressed_offset.stop,
-            self.valid_window.xstart,
-            self.valid_window.xend,
-            self.valid_window.ystart,
-            self.valid_window.yend,
-        )
-        return tuppled
-
-    def to_bytes(self):
-        data = (
-            self.shape[0],
-            self.shape[1],
-            self.index_offset.start,
-            self.index_offset.stop,
-            self.uncompressed_offset.start,
-            self.uncompressed_offset.stop,
-            self.valid_window.xstart,
-            self.valid_window.xend,
-            self.valid_window.ystart,
-            self.valid_window.yend,
-        )
-        byte_metadata = b'BURST' + struct.pack('<QQQQQQQQQQ', *data)
-        return byte_metadata
-
     def to_dict(self):
         dictionary = {
             'name': self.name,
@@ -145,9 +112,6 @@ class XmlMetadata:
     name: str
     slc: str
     offset: Offset
-
-    def to_tuple(self):
-        return (self.name, self.slc, self.offset.start, self.offset.stop)
 
     def to_dict(self):
         return {self.slc: {self.name: {'offset_start': self.offset.start, 'offset_stop': self.offset.stop}}}


### PR DESCRIPTION
Also:
- Update `extract_metadata` CLI interface
- Remove unused methods from `BurstMetadata` and `XmlMetadata`